### PR TITLE
add space for QQ msg

### DIFF
--- a/src/multichat.py
+++ b/src/multichat.py
@@ -41,7 +41,7 @@ class MultiChatWS():
             if data['action'] == 'forwarding-message':
                 source = data['source-client-name']
                 content = data['content']
-                post_str = '[{}]{}'.format(source, content)
+                post_str = '[{}] {}'.format(source, content)
                 await qqws.post(post_str)
         
     


### PR DESCRIPTION
Modified `multichat.py` to add a space between `source` and `content` texts for QQ messages.

To be more Specific:

Before: `[MC-Survival]FlagerLee was killed by Zombified Piglin`

After: `[MC-Survival] FlagerLee was killed by Zombified Piglin`